### PR TITLE
Improve scene heading splitting

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,8 +1,12 @@
 function breakdownScript() {
   const input = document.getElementById("scriptInput").value;
 
-  // This splits on any line starting with INT. or EXT.
-  const scenes = input.split(/\n(?=INT\.|EXT\.)/g).filter(Boolean);
+  // Split on lines that start with scene headings such as
+  // INT., EXT., INT/EXT or EXT./INT. The match is case-insensitive
+  // and ignores optional spaces and periods around the slash.
+  const scenes = input
+    .split(/\n(?=[ \t]*(?:INT|EXT)\.?[ \t]*(?:\/[ \t]*(?:INT|EXT)\.?)?)/gi)
+    .filter(Boolean);
 
   const output = document.getElementById("output");
   output.innerHTML = '';

--- a/test/regex.test.js
+++ b/test/regex.test.js
@@ -1,0 +1,39 @@
+const assert = require('assert');
+
+// Replicate the regex used in script.js
+const SCENE_SPLIT_REGEX = /\n(?=[ \t]*(?:INT|EXT)\.?[ \t]*(?:\/[ \t]*(?:INT|EXT)\.?)?)/gi;
+
+function splitScenes(text) {
+  return text.split(SCENE_SPLIT_REGEX).filter(Boolean);
+}
+
+const script = [
+  'INT. HOUSE',
+  'line1',
+  'EXT. STREET',
+  'line2',
+  'INT/EXT CAR',
+  'line3',
+  'EXT./INT OFFICE',
+  'line4',
+  'int/ext basement',
+  'line5',
+  'ext/int field',
+  'line6'
+].join('\n');
+
+const scenes = splitScenes(script);
+
+assert.deepStrictEqual(
+  scenes.map(s => s.split('\n')[0].trim()),
+  [
+    'INT. HOUSE',
+    'EXT. STREET',
+    'INT/EXT CAR',
+    'EXT./INT OFFICE',
+    'int/ext basement',
+    'ext/int field'
+  ]
+);
+
+console.log('Tests passed');


### PR DESCRIPTION
## Summary
- support more scene heading variations
- add minimal Node test for the regex

## Testing
- `node test/regex.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68786896bcb4832981ee0bb550e3e3c2